### PR TITLE
Fix CheckUpdatesThread signal definitions

### DIFF
--- a/imswitch/imcommon/controller/CheckUpdatesController.py
+++ b/imswitch/imcommon/controller/CheckUpdatesController.py
@@ -45,13 +45,14 @@ class CheckUpdatesController(WidgetController):
 
 
 class CheckUpdatesThread(Thread):
+    sigFailed = Signal()
+    sigNoUpdate = Signal()
+    sigNewVersionPyInstaller = Signal(str)  # (latestVersion)
+    sigNewVersionPyPI = Signal(str)  # (latestVersion)
+    sigNewVersionShowInfo = Signal(str) # (someText)
+
     def __init__(self):
         super().__init__()
-        self.sigFailed = Signal()
-        self.sigNoUpdate = Signal()
-        self.sigNewVersionPyInstaller = Signal(str)  # (latestVersion)
-        self.sigNewVersionPyPI = Signal(str)  # (latestVersion)
-        self.sigNewVersionShowInfo = Signal(str) # (someText)
         self.__logger = initLogger(self, tryInheritParent=True)
 
     def run(self):


### PR DESCRIPTION
## Summary
- declare the CheckUpdatesThread update signals as class attributes
- keep the thread constructor focused on base initialization and logger setup

## Testing
- python -m imswitch *(fails: ModuleNotFoundError: No module named 'PyQt5')*


------
https://chatgpt.com/codex/tasks/task_e_68dbae8657a48324b1d1f6543967b5b0